### PR TITLE
Add native window buttons for Mac OS X

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -12,7 +12,19 @@ app.on("window-all-closed", function () {
 });
 
 app.on("ready", function () {
-	mainWindow = new BrowserWindow({ width : 960, height: 640, frame : false });
+
+	var windowOptions = {
+		width  : 960,
+		height : 640,
+		frame  : false
+	}
+
+	if (process.platform === "darwin") {
+		windowOptions.frame = true;
+		windowOptions["title-bar-style"] = "hidden-inset";
+	}
+
+	mainWindow = new BrowserWindow(windowOptions);
 	mainWindow.loadUrl("file://" + path.join(__dirname, "..", "index.html"));
 
 	if (process.env.DEBUG === "true") {

--- a/chug.js
+++ b/chug.js
@@ -42,6 +42,12 @@ document.addEventListener("DOMContentLoaded", function () {
 	$(".expander").click(togglePanelExpanded);
 
 	$("#identity").keyup(updateInfo);
+
+	if (process.platform === "darwin") {
+		$(".window-minimize").hide();
+		$(".window-maximize").hide();
+		$(".window-close").hide();
+	}
 });
 
 function saveUserData () {


### PR DESCRIPTION
On Mac OS X, Yosemite and newer, native window buttons will be used in place of
the HTML window buttons. These will be hidden after the DOM finishes loading
but it would be nice if they never showed up to begin with.
